### PR TITLE
createHandlers is too destructive

### DIFF
--- a/coffee/jquery.resizableColumns.coffee
+++ b/coffee/jquery.resizableColumns.coffee
@@ -44,7 +44,7 @@
         setWidth $el[0], ($el.outerWidth() / @$table.width() * 100)
 
     createHandles: ->
-      $('.rc-handle-container').remove()
+      @$handleContainer?.remove()
       @$table.before (@$handleContainer = $("<div class='rc-handle-container' />"))
       @$tableHeaders.each (i, el) =>
         return if @$tableHeaders.eq(i + 1).length == 0 ||


### PR DESCRIPTION
The first line in createHandlers is:

```
$('.rc-handle-container').remove()
```

Doesn't that mean that if I have 2 tables in the same page, the construction of the second table will cause the destruction of the first table's handles?

I propose to remove only the handle container for that table.
