### PR TITLE
Ensure plugin uses store passed into options

### DIFF
--- a/coffee/jquery.resizableColumns.coffee
+++ b/coffee/jquery.resizableColumns.coffee
@@ -70,12 +70,12 @@
         $el = $(el)
         unless $el.attr('data-noresize')?
           if @options.store?
-            store.set @getColumnId($el), parseWidth($el[0])
+            @options.store.set @getColumnId($el), parseWidth($el[0])
 
     restoreColumnWidths: ->
       @$tableHeaders.each (_, el) =>
         $el = $(el)
-        if @options.store? && (width = store.get(@getColumnId($el)))
+        if @options.store? && (width = @options.store.get(@getColumnId($el)))
           setWidth $el[0], width
 
     totalColumnWidths: ->

--- a/js/jquery.resizableColumns.js
+++ b/js/jquery.resizableColumns.js
@@ -101,7 +101,7 @@ var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments)
         $el = $(el);
         if ($el.attr('data-noresize') == null) {
           if (_this.options.store != null) {
-            return store.set(_this.getColumnId($el), parseWidth($el[0]));
+            return _this.options.store.set(_this.getColumnId($el), parseWidth($el[0]));
           }
         }
       });
@@ -114,7 +114,7 @@ var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments)
         var $el, width;
 
         $el = $(el);
-        if ((_this.options.store != null) && (width = store.get(_this.getColumnId($el)))) {
+        if ((_this.options.store != null) && (width = _this.options.store.get(_this.getColumnId($el)))) {
           return setWidth($el[0], width);
         }
       });


### PR DESCRIPTION
Plugin was assuming store was in the window namespace. Now it will reliably use the store passed into options.
