### PR TITLE
Update jquery.resizableColumns.js

### DIFF
--- a/coffee/jquery.resizableColumns.coffee
+++ b/coffee/jquery.resizableColumns.coffee
@@ -115,6 +115,8 @@
         $(document).off 'mousemove.rc touchmove.rc'
         @$table.removeClass('rc-table-resizing')
         @syncHandleWidths()
+        
+        typeof @options.onResized === "function" && @options.onResized();
         @saveColumnWidths()
 
   # Define the plugin

--- a/js/jquery.resizableColumns.js
+++ b/js/jquery.resizableColumns.js
@@ -35,6 +35,12 @@ var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments)
         return _this.syncHandleWidths();
       }));
     }
+      
+    ResizableColumns.prototype.reset = function () {
+        this.setHeaders();
+        this.restoreColumnWidths();
+        this.syncHandleWidths();
+    };
 
     ResizableColumns.prototype.getColumnId = function($el) {
       return this.$table.data('resizable-columns-id') + '-' + $el.data('resizable-column-id');
@@ -166,10 +172,15 @@ var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments)
         $table = $(this);
         data = $table.data('resizableColumns');
         if (!data) {
-          $table.data('resizableColumns', (data = new ResizableColumns($table, option)));
+            $table.data('resizableColumns', (data = new ResizableColumns($table, option)));
         }
+        
         if (typeof option === 'string') {
           return data[option].apply(data, args);
+        }
+
+        if (option && option.reset) {
+            data.reset();
         }
       });
     }


### PR DESCRIPTION
If you modify the table headings at runtime (add/removing th's) the handlers don't get updated and there is no way to update them manually.

This PR adds a new method and an additional option to tell the widget to reset the positions of the handlers.

There is probably a cleaner way to do this but this gets the ball rolling
