### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "jquery-resizable-columns",
+  "main": "dist/jquery.resizableColumns.min.js",
   "version": "0.0.1",
   "homepage": "https://github.com/dobtco/jquery-resizable-columns",
   "authors": [


### PR DESCRIPTION
Currently the bower install points to the Gruntfile by default. Set `main` property to point to the `dist` directories built file :)
