### PR TITLE
Add support for tables w/o headers via `selector`

### DIFF
--- a/coffee/jquery.resizableColumns.coffee
+++ b/coffee/jquery.resizableColumns.coffee
@@ -17,6 +17,7 @@
   class ResizableColumns
 
     defaults:
+      selector: 'tr th:visible' # determine columns using visible table headers
       store: window.store
       syncHandlers: true # immediately synchronize handlers with column widths
       resizeFromBody: true # allows for resizing of columns from within tbody
@@ -35,7 +36,7 @@
       @$table.data('resizable-columns-id') + '-' + $el.data('resizable-column-id')
 
     setHeaders: ->
-      @$tableHeaders = @$table.find('tr th:visible')
+      @$tableHeaders = @$table.find(@options.selector)
       @assignPercentageWidths()
       @createHandles()
 


### PR DESCRIPTION
Add overridable `selector` to default `options` object, which determines which elements are selected and used as the detected columns for the table.
