### PR TITLE
Add event support

### DIFF
--- a/coffee/jquery.resizableColumns.coffee
+++ b/coffee/jquery.resizableColumns.coffee
@@ -55,7 +55,7 @@
     destroy: ->
       @$handleContainer.remove()
       @$table.removeData('resizableColumns')
-      $(window).off '.rc'
+      @$table.add(window).off '.rc'
 
     assignPercentageWidths: ->
       @$tableHeaders.each (_, el) =>

--- a/coffee/jquery.resizableColumns.coffee
+++ b/coffee/jquery.resizableColumns.coffee
@@ -120,8 +120,8 @@
       
       $(document).on 'mousemove.rc touchmove.rc', (e) =>
         difference = (pointerX(e) - startPosition) / @$table.width() * 100
-        setWidth($rightColumn[0], newWidths.left = widths.right - difference)
-        setWidth($leftColumn[0], newWidths.right = widths.left + difference)
+        setWidth($leftColumn[0], newWidths.left = widths.left + difference)
+        setWidth($rightColumn[0], newWidths.right = widths.right - difference)
         if @options.syncHandlers?
           @syncHandleWidths()
         @$table.trigger 'column:resize', [ $leftColumn, $rightColumn, newWidths.left, newWidths.right ]

--- a/coffee/jquery.resizableColumns.coffee
+++ b/coffee/jquery.resizableColumns.coffee
@@ -37,7 +37,7 @@
       if @options.resize
         @$table.bind('column:resize.rc', @options.resize)
       if @options.end
-        @$table.bind('column:resize:end.rc', @options.end)
+        @$table.bind('column:resize:stop.rc', @options.end)
         
     getColumnId: ($el) ->
       @$table.data('resizable-columns-id') + '-' + $el.data('resizable-column-id')

--- a/coffee/jquery.resizableColumns.coffee
+++ b/coffee/jquery.resizableColumns.coffee
@@ -36,8 +36,8 @@
         @$table.bind('column:resize:start.rc', @options.start)
       if @options.resize
         @$table.bind('column:resize.rc', @options.resize)
-      if @options.end
-        @$table.bind('column:resize:stop.rc', @options.end)
+      if @options.stop
+        @$table.bind('column:resize:stop.rc', @options.stop)
         
     getColumnId: ($el) ->
       @$table.data('resizable-columns-id') + '-' + $el.data('resizable-column-id')

--- a/coffee/jquery.resizableColumns.coffee
+++ b/coffee/jquery.resizableColumns.coffee
@@ -38,7 +38,12 @@
         @$table.bind('column:resize.rc', @options.resize)
       if @options.stop
         @$table.bind('column:resize:stop.rc', @options.stop)
-        
+
+    triggerEvent: (type, args, original) ->
+      event = $.Event type
+      event.originalEvent = $.extend {}, original
+      @$table.trigger event, [this].concat(args || [])
+
     getColumnId: ($el) ->
       @$table.data('resizable-columns-id') + '-' + $el.data('resizable-column-id')
 
@@ -116,7 +121,7 @@
         
       @$handleContainer.addClass('rc-table-resizing')
       @$table.addClass('rc-table-resizing')
-      @$table.trigger 'column:resize:start', [ $leftColumn, $rightColumn ]
+      @triggerEvent 'column:resize:start', [ $leftColumn, $rightColumn ], e
       
       $(document).on 'mousemove.rc touchmove.rc', (e) =>
         difference = (pointerX(e) - startPosition) / @$table.width() * 100
@@ -124,7 +129,7 @@
         setWidth($rightColumn[0], newWidths.right = widths.right - difference)
         if @options.syncHandlers?
           @syncHandleWidths()
-        @$table.trigger 'column:resize', [ $leftColumn, $rightColumn, newWidths.left, newWidths.right ]
+        @triggerEvent 'column:resize', [ $currentGrip, $leftColumn, $rightColumn, newWidths.left, newWidths.right ], e
         
       $(document).one 'mouseup touchend', =>
         $(document).off 'mousemove.rc touchmove.rc'
@@ -132,8 +137,8 @@
         @$table.removeClass('rc-table-resizing')
         @syncHandleWidths()
         @saveColumnWidths()
-        @$table.trigger 'column:resize:stop', [ $leftColumn, $rightColumn, newWidths.left, newWidths.right ]
-
+        @triggerEvent 'column:resize:stop', [ $leftColumn, $rightColumn, newWidths.left, newWidths.right ], e
+        
   # Define the plugin
   $.fn.extend resizableColumns: (option, args...) ->
     @each ->


### PR DESCRIPTION
Add `.trigger()` calls to all 3 stages of the resizing process (start, resize, stop)

``` js
column:resize:start // Passed [ $leftColumn, $rightColumn ]
column:resize // Passed [ $leftColumn, $rightColumn, newLeftWidths, newRightWidths ]
column:resize:stop // Passed [ $leftColumn, $rightColumn, newLeftWidths, newRightWidths ]
```
