### PR TITLE
Changed jquery requirement constraint

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,6 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "^1.9.0"
+    "jquery": ">1.9.0"
   }
 }


### PR DESCRIPTION
The requirement constraint of the Jquery plugin was changed to allow newest Jquery versions to be used